### PR TITLE
Use the transaction domain tag in signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init --recursive
+      - run: apt-get update && apt-get -y install python3.6 && apt -y install python3-pip && pip3 install conan
       - run: cmake -DCMAKE_BUILD_TYPE=Debug . && make
       # Unfortunately need to disable leak sanitizer https://github.com/google/sanitizers/issues/916
       # Still run all other ASAN components

--- a/app/src/common/actions.h
+++ b/app/src/common/actions.h
@@ -25,8 +25,8 @@
 extern uint16_t action_addr_len;
 
 __Z_INLINE void app_sign() {
-    const uint8_t *message = tx_get_buffer();
-    const uint16_t messageLength = tx_get_buffer_length();
+    const uint8_t *message = get_signable();
+    const uint16_t messageLength = get_signable_length();
 
     uint16_t replyLen = 0;
     zxerr_t err = crypto_sign(G_io_apdu_buffer, IO_APDU_BUFFER_SIZE - 3, message, messageLength, &replyLen);

--- a/app/src/common/tx.c
+++ b/app/src/common/tx.c
@@ -44,6 +44,15 @@ storage_t NV_CONST N_appdata_impl __attribute__ ((aligned(64)));
 
 parser_context_t ctx_parsed_tx;
 
+#define DOMAIN_TAG_LENGTH 32
+// UTF-8 encoding of "FLOW-V0.0-transaction" padded with zeros to 32 bytes
+const uint8_t TX_DOMAIN_TAG[DOMAIN_TAG_LENGTH] = {\
+    0x46, 0x4C, 0x4F, 0x57, 0x2D, 0x56, 0x30, 0x2E, 
+    0x30, 0x2D, 0x74, 0x72, 0x61, 0x6E, 0x73, 0x61, 
+    0x63, 0x74, 0x69, 0x6F, 0x6E,    0,    0,    0,
+       0,    0,    0,    0,    0,    0,    0,    0,
+};
+
 void tx_initialize() {
     buffering_init(
             ram_buffer,
@@ -55,6 +64,7 @@ void tx_initialize() {
 
 void tx_reset() {
     buffering_reset();
+    buffering_append(TX_DOMAIN_TAG, DOMAIN_TAG_LENGTH);
 }
 
 uint32_t tx_append(unsigned char *buffer, uint32_t length) {
@@ -62,10 +72,21 @@ uint32_t tx_append(unsigned char *buffer, uint32_t length) {
 }
 
 uint32_t tx_get_buffer_length() {
+    if (buffering_get_buffer()->pos >= DOMAIN_TAG_LENGTH) {
+        return buffering_get_buffer()->pos - DOMAIN_TAG_LENGTH;
+    }
+    return 0;
+}
+
+uint32_t get_signable_length() {
     return buffering_get_buffer()->pos;
 }
 
 uint8_t *tx_get_buffer() {
+    return buffering_get_buffer()->data + DOMAIN_TAG_LENGTH;
+}
+
+uint8_t *get_signable() {
     return buffering_get_buffer()->data;
 }
 

--- a/app/src/common/tx.c
+++ b/app/src/common/tx.c
@@ -44,14 +44,16 @@ storage_t NV_CONST N_appdata_impl __attribute__ ((aligned(64)));
 
 parser_context_t ctx_parsed_tx;
 
-#define DOMAIN_TAG_LENGTH 32
 // UTF-8 encoding of "FLOW-V0.0-transaction" padded with zeros to 32 bytes
+#define DOMAIN_TAG_LENGTH 32
 const uint8_t TX_DOMAIN_TAG[DOMAIN_TAG_LENGTH] = {\
     0x46, 0x4C, 0x4F, 0x57, 0x2D, 0x56, 0x30, 0x2E, 
     0x30, 0x2D, 0x74, 0x72, 0x61, 0x6E, 0x73, 0x61, 
     0x63, 0x74, 0x69, 0x6F, 0x6E,    0,    0,    0,
        0,    0,    0,    0,    0,    0,    0,    0,
 };
+
+#define TX_BUFFER_OFFSET DOMAIN_TAG_LENGTH
 
 void tx_initialize() {
     buffering_init(
@@ -72,8 +74,8 @@ uint32_t tx_append(unsigned char *buffer, uint32_t length) {
 }
 
 uint32_t tx_get_buffer_length() {
-    if (buffering_get_buffer()->pos >= DOMAIN_TAG_LENGTH) {
-        return buffering_get_buffer()->pos - DOMAIN_TAG_LENGTH;
+    if (buffering_get_buffer()->pos >= TX_BUFFER_OFFSET) {
+        return buffering_get_buffer()->pos - TX_BUFFER_OFFSET;
     }
     return 0;
 }
@@ -83,7 +85,7 @@ uint32_t get_signable_length() {
 }
 
 uint8_t *tx_get_buffer() {
-    return buffering_get_buffer()->data + DOMAIN_TAG_LENGTH;
+    return buffering_get_buffer()->data + TX_BUFFER_OFFSET;
 }
 
 uint8_t *get_signable() {

--- a/app/src/common/tx.h
+++ b/app/src/common/tx.h
@@ -35,9 +35,18 @@ uint32_t tx_append(unsigned char *buffer, uint32_t length);
 /// \return
 uint32_t tx_get_buffer_length();
 
+/// Returns size of the signable buffer including the domain tag and the transaction
+/// \return
+uint32_t get_signable_length();
+
 /// Returns the raw json transaction buffer
 /// \return
 uint8_t *tx_get_buffer();
+
+/// Returns the signable buffer including the domain tag and the transaction
+/// \return
+uint8_t *get_signable();
+
 
 /// Parse message stored in transaction buffer
 /// This function should be called as soon as full buffer data is loaded.

--- a/tests_zemu/tests/test.js
+++ b/tests_zemu/tests/test.js
@@ -402,8 +402,12 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
-            hasher.update(txBlob)
+            hasher.update(tag);
+            hasher.update(txBlob);
             const digest = hasher.getHash("HEX");
 
             // Verify signature
@@ -453,7 +457,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -504,7 +512,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -555,7 +567,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -606,7 +622,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -657,7 +677,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -769,7 +793,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -820,7 +848,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -871,7 +903,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -922,7 +958,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -973,7 +1013,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 
@@ -1024,7 +1068,11 @@ describe('Basic checks', function () {
             expect(resp.errorMessage).toEqual("No errors");
 
             // Prepare digest
+            let tag = Buffer.alloc(32);
+            tag.write("FLOW-V0.0-transaction");
+
             const hasher = new jsSHA("SHA3-256", "UINT8ARRAY");
+            hasher.update(tag)
             hasher.update(txBlob)
             const digest = hasher.getHash("HEX");
 


### PR DESCRIPTION
This PR addresses #28 

- prepend data buffer by a hardcoded transaction tag.
- generate signatures using the entire buffer, including the tag.
- update zemu tests.