### PR TITLE
Optional support

### DIFF
--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -193,6 +193,37 @@ parser_error_t parser_printArgument(const flow_argument_list_t *v,
     return PARSER_OK;
 }
 
+
+parser_error_t parser_printArgumentOptionalDelegatorID(const flow_argument_list_t *v,
+                                               uint8_t argIndex, char *expectedType, jsmntype_t jsonType,
+                                               char *outVal, uint16_t outValLen,
+                                               uint8_t pageIdx, uint8_t *pageCount) {
+    MEMZERO(outVal, outValLen);
+
+    if (argIndex >= v->argCount) {
+        return PARSER_UNEXPECTED_NUMBER_ITEMS;
+    }
+
+    *pageCount = 1;
+
+    parsed_json_t parsedJson = {false};
+    CHECK_PARSER_ERR(json_parse(&parsedJson, (char *) v->argCtx[argIndex].buffer, v->argCtx[argIndex].bufferLen));
+    uint16_t valueTokenIndex;
+    CHECK_PARSER_ERR(json_matchOptionalKeyValue(&parsedJson, 0, expectedType, jsonType, &valueTokenIndex))
+    if (valueTokenIndex == JSON_MATCH_VALUE_IDX_NONE) {
+        if (outValLen < 5) {
+            return PARSER_UNEXPECTED_BUFFER_END;
+        }         
+        strncpy_s(outVal, "None", 5);
+    }
+    else {
+        CHECK_PARSER_ERR(json_extractToken(outVal, outValLen, &parsedJson, valueTokenIndex))
+    }
+
+    return PARSER_OK;
+}
+
+
 parser_error_t parser_printArgumentString(const parser_context_t *argumentCtx,
                                              char *outVal, uint16_t outValLen,
                                              uint8_t pageIdx, uint8_t *pageCount) {

--- a/app/src/parser.h
+++ b/app/src/parser.h
@@ -22,6 +22,7 @@ extern "C" {
 
 #include "parser_impl.h"
 #include "crypto.h"
+#include "jsmn.h"
 
 const char *parser_getErrorDescription(parser_error_t err);
 
@@ -42,6 +43,13 @@ parser_error_t parser_getItem(const parser_context_t *ctx,
                               char *outKey, uint16_t outKeyLen,
                               char *outVal, uint16_t outValLen,
                               uint8_t pageIdx, uint8_t *pageCount);
+
+
+////for testing purposes
+parser_error_t parser_printArgumentOptionalDelegatorID(const flow_argument_list_t *v,
+                                               uint8_t argIndex, char *expectedType, jsmntype_t jsonType,
+                                               char *outVal, uint16_t outValLen,
+                                               uint8_t pageIdx, uint8_t *pageCount);
 
 #ifdef __cplusplus
 }

--- a/app/src/parser_impl.c
+++ b/app/src/parser_impl.c
@@ -200,7 +200,7 @@ parser_error_t json_matchKeyValue(parsed_json_t *parsedJson,
     CHECK_PARSER_ERR(json_validateToken(parsedJson, tokenIdx))
 
     if (tokenIdx + 4 >= parsedJson->numberOfTokens) {
-        // we need this token a 4 more
+        // we need this token and 4 more
         return PARSER_JSON_INVALID_TOKEN_IDX;
     }
 
@@ -231,7 +231,7 @@ parser_error_t json_matchOptionalKeyValue(parsed_json_t *parsedJson,
     CHECK_PARSER_ERR(json_validateToken(parsedJson, tokenIdx))
 
     if (tokenIdx + 4 >= parsedJson->numberOfTokens) {
-        // we need this token a 4 more
+        // we need this token and 4 more
         return PARSER_JSON_INVALID_TOKEN_IDX;
     }
 

--- a/app/src/parser_impl.h
+++ b/app/src/parser_impl.h
@@ -25,6 +25,7 @@
 extern "C" {
 #endif
 
+
 extern parser_tx_t parser_tx_obj;
 
 parser_error_t parser_init(parser_context_t *ctx, const uint8_t *buffer, uint16_t bufferSize);
@@ -45,7 +46,13 @@ parser_error_t json_extractToken(char *outVal, uint16_t outValLen, parsed_json_t
 
 parser_error_t json_matchToken(parsed_json_t *parsedJson, uint16_t tokenIdx, char *expectedValue);
 
+parser_error_t json_matchNull(parsed_json_t *parsedJson, uint16_t tokenIdx);
+
 parser_error_t json_matchKeyValue(parsed_json_t *parsedJson,
+                                  uint16_t tokenIdx, char *expectedType, jsmntype_t jsonType, uint16_t *valueTokenIdx);
+
+#define JSON_MATCH_VALUE_IDX_NONE 65535
+parser_error_t json_matchOptionalKeyValue(parsed_json_t *parsedJson,
                                   uint16_t tokenIdx, char *expectedType, jsmntype_t jsonType, uint16_t *valueTokenIdx);
 
 parser_error_t formatStrUInt8AsHex(const char *decStr, char *hexStr);

--- a/tests/json.cpp
+++ b/tests/json.cpp
@@ -24,6 +24,9 @@
 
 const auto sendToken = "{\"type\":\"UFix64\",\"value\":\"545.77\"}";
 
+const auto sendToken2 = "{\"type\":\"Optional\",\"value\":null}";
+const auto sendToken3 = "{\"type\":\"Optional\",\"value\":{\"type\":\"UFix64\",\"value\":\"545.77\"}}";
+
 const auto validCreationInput = "{\n"
                                 "  \"type\": \"Array\",\n"
                                 "  \"value\": [\n"
@@ -116,4 +119,89 @@ TEST(JSON, basicSingleKeyValue) {
             json_matchKeyValue(&parsedJson, 0, (char *) "UFix64", JSMN_STRING, &internalTokenElementIdx),
             PARSER_OK);
     ASSERT_THAT(internalTokenElementIdx, 4);
+}
+
+TEST(JSON, OptionalKeyValueNull) {
+    parsed_json_t parsedJson = {false};
+
+    auto err = json_parse(&parsedJson, sendToken2, strlen(sendToken2));
+
+     // We could parse valid JSON
+    EXPECT_THAT(err, PARSER_OK);
+    EXPECT_TRUE(parsedJson.isValid);
+    EXPECT_EQ(5, parsedJson.numberOfTokens);
+
+    EXPECT_EQ(parsedJson.tokens[0].type, jsmntype_t::JSMN_OBJECT);
+    EXPECT_EQ(parsedJson.tokens[1].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[2].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[3].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[4].type, jsmntype_t::JSMN_PRIMITIVE);
+
+    char tmpBuffer[100];
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 1), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "type");
+    ASSERT_THAT(json_matchToken(&parsedJson, 1, (char *) "type"), PARSER_OK);
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 2), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "Optional");
+    ASSERT_THAT(json_matchToken(&parsedJson, 2, (char *) "Optional"), PARSER_OK);
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 3), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "value");
+    ASSERT_THAT(json_matchToken(&parsedJson, 3, (char *) "value"), PARSER_OK);
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 4), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "null");
+    ASSERT_THAT(json_matchNull(&parsedJson, 4), PARSER_OK);
+
+    uint16_t internalTokenElementIdx;
+    EXPECT_EQ(5, parsedJson.numberOfTokens);
+    ASSERT_THAT(
+            json_matchOptionalKeyValue(&parsedJson, 0, (char *) "UFix64", JSMN_STRING, &internalTokenElementIdx),
+            PARSER_OK);
+    ASSERT_THAT(internalTokenElementIdx, JSON_MATCH_VALUE_IDX_NONE);
+}
+
+
+TEST(JSON, OptionalKeyValueNotNull) {
+    parsed_json_t parsedJson = {false};
+
+    auto err = json_parse(&parsedJson, sendToken3, strlen(sendToken3));
+
+     // We could parse valid JSON
+    EXPECT_THAT(err, PARSER_OK);
+    EXPECT_TRUE(parsedJson.isValid);
+    EXPECT_EQ(9, parsedJson.numberOfTokens);
+
+    EXPECT_EQ(parsedJson.tokens[0].type, jsmntype_t::JSMN_OBJECT);
+    EXPECT_EQ(parsedJson.tokens[1].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[2].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[3].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[4].type, jsmntype_t::JSMN_OBJECT);
+    EXPECT_EQ(parsedJson.tokens[5].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[6].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[7].type, jsmntype_t::JSMN_STRING);
+    EXPECT_EQ(parsedJson.tokens[8].type, jsmntype_t::JSMN_STRING);
+
+    char tmpBuffer[100];
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 1), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "type");
+    ASSERT_THAT(json_matchToken(&parsedJson, 1, (char *) "type"), PARSER_OK);
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 2), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "Optional");
+    ASSERT_THAT(json_matchToken(&parsedJson, 2, (char *) "Optional"), PARSER_OK);
+
+    ASSERT_THAT(json_extractToken(tmpBuffer, sizeof(tmpBuffer), &parsedJson, 3), PARSER_OK);
+    EXPECT_STREQ(tmpBuffer, "value");
+    ASSERT_THAT(json_matchToken(&parsedJson, 3, (char *) "value"), PARSER_OK);
+
+
+    uint16_t internalTokenElementIdx;
+    ASSERT_THAT(
+            json_matchOptionalKeyValue(&parsedJson, 0, (char *) "UFix64", JSMN_STRING, &internalTokenElementIdx),
+            PARSER_OK);
+    ASSERT_THAT(internalTokenElementIdx, 8);
 }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+*   (c) 2020 Zondax GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#include "gmock/gmock.h"
+#include <iostream>
+#include <stdlib.h>
+#include <hexutils.h>
+#include <json/json_parser.h>
+#include <parser.h>
+#include <string.h>
+
+
+const auto token2 = "{\"type\":\"Optional\",\"value\":null}";
+parser_context_t context2 = {(const uint8_t *)token2, strlen(token2), 0};
+const auto token3 = "{\"type\":\"Optional\",\"value\":{\"type\":\"UFix64\",\"value\":\"545.77\"}}";
+parser_context_t context3 = {(const uint8_t *)token3, strlen(token3), 0};
+
+flow_argument_list_t arg_list = {{},{context2, context3},2};
+
+TEST(parser, printOptional) {
+    char outValBuf[40];
+    uint8_t pageCountVar = 0;
+
+    char ufix64[] = "UFix64";
+    parser_error_t err = parser_printArgumentOptionalDelegatorID(&arg_list, 0, ufix64, JSMN_STRING,
+                                               outValBuf, 40, 0, &pageCountVar);
+    EXPECT_THAT(err, PARSER_OK);
+    EXPECT_THAT(pageCountVar, 1);
+    EXPECT_STREQ(outValBuf, "None");
+
+    err = parser_printArgumentOptionalDelegatorID(&arg_list, 1, ufix64, JSMN_STRING,
+                                               outValBuf, 40, 1, &pageCountVar);
+    EXPECT_THAT(err, PARSER_OK);
+    EXPECT_STREQ(outValBuf, "545.77");
+    EXPECT_THAT(pageCountVar, 1);
+
+}
+


### PR DESCRIPTION
Implements support for optional delegatorID arguments required by stakingCollection transactions. Makes it easier to support further optional parameters in the future. Does not change the behaviour of the app. Some details of parsing delegatorID arguments may need to change, but they should be easy to implement after this.