### PR TITLE
RLP: fix len_len overflow and add negative parsing tests

### DIFF
--- a/app/src/rlp.c
+++ b/app/src/rlp.c
@@ -20,6 +20,9 @@
     if (ctx->offset > ctx->bufferLen) return PARSER_UNEXPECTED_BUFFER_END; \
     if (ctx->bufferLen - ctx->offset < size ) return PARSER_UNEXPECTED_BUFFER_END;
 
+#define CHECK_LEN_LEN_MAX(len_len, size) \
+    if (len_len > size) return PARSER_RLP_ERROR_INVALID_VALUE_LEN;
+
 parser_error_t rlp_decode(
         const parser_context_t *input,
         parser_context_t *outputPayload,
@@ -57,6 +60,7 @@ parser_error_t rlp_decode(
         *outputKind = RLP_KIND_STRING;
         const uint8_t len_len = p - 0xb7;
         CHECK_AVAILABLE(input, 1 + len_len)
+        CHECK_LEN_LEN_MAX(len_len, sizeof(outputPayload->bufferLen));
 
         outputPayload->bufferLen = 0;
         for (uint8_t i = 0; i < len_len; i++) {
@@ -82,6 +86,7 @@ parser_error_t rlp_decode(
         *outputKind = RLP_KIND_LIST;
         const uint8_t len_len = p - 0xf7;
         CHECK_AVAILABLE(input, 1 + len_len)
+        CHECK_LEN_LEN_MAX(len_len, sizeof(outputPayload->bufferLen));
 
         outputPayload->bufferLen = 0;
         for (uint8_t i = 0; i < len_len; i++) {

--- a/tests/rlp.cpp
+++ b/tests/rlp.cpp
@@ -24,6 +24,7 @@ using ::testing::Values;
 
 struct RLPValueTestCase {
     const char *data;
+    parser_error_t expectedError;
     uint8_t expectedKind;
     uint64_t expectedLen;
     uint64_t expectedDataOffset;
@@ -42,19 +43,19 @@ INSTANTIATE_TEST_SUITE_P(
         InstantiationName,
         RLPDecodeTest,
         Values(
-                RLPValueTestCase{"00", RLP_KIND_STRING, 1, 0, 1}, // Byte string (00)
-                RLPValueTestCase{"01", RLP_KIND_STRING, 1, 0, 1}, // Byte string (01)
-                RLPValueTestCase{"7F", RLP_KIND_STRING, 1, 0, 1}, // Byte string (7F)
+                RLPValueTestCase{"00", PARSER_OK, RLP_KIND_STRING, 1, 0, 1}, // Byte string (00)
+                RLPValueTestCase{"01", PARSER_OK, RLP_KIND_STRING, 1, 0, 1}, // Byte string (01)
+                RLPValueTestCase{"7F", PARSER_OK, RLP_KIND_STRING, 1, 0, 1}, // Byte string (7F)
 
-                RLPValueTestCase{"80", RLP_KIND_STRING, 0, 1, 1},       // Empty string ("")
-                RLPValueTestCase{"83646F67", RLP_KIND_STRING, 3, 1, 4}, // Short string ("dog")
+                RLPValueTestCase{"80", PARSER_OK, RLP_KIND_STRING, 0, 1, 1},       // Empty string ("")
+                RLPValueTestCase{"83646F67", PARSER_OK, RLP_KIND_STRING, 3, 1, 4}, // Short string ("dog")
 
                 RLPValueTestCase{"B7"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
-                                 "0000000000000000000000000000000000000000000000000000000000000000", RLP_KIND_STRING, 55, 1,
-                                 56},
+                                 "0000000000000000000000000000000000000000000000000000000000000000",
+                                 PARSER_OK, RLP_KIND_STRING, 55, 1, 56},
                 RLPValueTestCase{"B90400"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
@@ -87,16 +88,16 @@ INSTANTIATE_TEST_SUITE_P(
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
-                                 "0000000000000000000000000000000000000000000000000000000000000000", RLP_KIND_STRING, 1024,
-                                 3, 1027},
-                RLPValueTestCase{"C0", RLP_KIND_LIST, 0, 1, 1},
-                RLPValueTestCase{"C80000000000000000", RLP_KIND_LIST, 8, 1, 9},
+                                 "0000000000000000000000000000000000000000000000000000000000000000",
+                                 PARSER_OK, RLP_KIND_STRING, 1024, 3, 1027},
+                RLPValueTestCase{"C0", PARSER_OK, RLP_KIND_LIST, 0, 1, 1},
+                RLPValueTestCase{"C80000000000000000", PARSER_OK, RLP_KIND_LIST, 8, 1, 9},
                 RLPValueTestCase{"F7"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
-                                 "0000000000000000000000000000000000000000000000000000000000000000", RLP_KIND_LIST, 55, 1,
-                                 56},
+                                 "0000000000000000000000000000000000000000000000000000000000000000",
+                                 PARSER_OK, RLP_KIND_LIST, 55, 1, 56},
                 RLPValueTestCase{"F90400"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
@@ -129,8 +130,21 @@ INSTANTIATE_TEST_SUITE_P(
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
                                  "0000000000000000000000000000000000000000000000000000000000000000"
-                                 "0000000000000000000000000000000000000000000000000000000000000000", RLP_KIND_LIST, 1024, 3,
-                                 1027}
+                                 "0000000000000000000000000000000000000000000000000000000000000000",
+                                 PARSER_OK, RLP_KIND_LIST, 1024, 3, 1027},
+                // Varios invalid RLP data examples
+                RLPValueTestCase{"", PARSER_UNEXPECTED_BUFFER_END, RLP_KIND_UNKNOWN, 0, 0, 0},
+
+                RLPValueTestCase{"BB", PARSER_UNEXPECTED_BUFFER_END, RLP_KIND_STRING, 0, 0, 0},
+
+                RLPValueTestCase{"B800", PARSER_OK, RLP_KIND_STRING, 0, 2, 2},
+
+                RLPValueTestCase{"B900", PARSER_UNEXPECTED_BUFFER_END, RLP_KIND_STRING, 0, 0, 0},
+                RLPValueTestCase{"B90000", PARSER_OK, RLP_KIND_STRING, 0, 3, 3},
+                RLPValueTestCase{"B9000100", PARSER_OK, RLP_KIND_STRING, 1, 3, 4},
+
+                RLPValueTestCase{"BA000000", PARSER_RLP_ERROR_INVALID_VALUE_LEN, RLP_KIND_STRING, 0, 0, 0},
+                RLPValueTestCase{"BB01000000", PARSER_RLP_ERROR_INVALID_VALUE_LEN, RLP_KIND_STRING, 0, 0, 0}
         )
 );
 
@@ -152,7 +166,7 @@ TEST_P(RLPDecodeTest, decodeElement) {
 
     parser_error_t err = rlp_decode(&ctx_in, &ctx_out, &kind, &bytesConsumed);
 
-    EXPECT_THAT(err, PARSER_OK);
+    EXPECT_THAT(err, testing::Eq(params.expectedError));
     EXPECT_THAT(kind, testing::Eq(params.expectedKind));
     EXPECT_THAT(ctx_out.bufferLen, testing::Eq(params.expectedLen));
     EXPECT_THAT(ctx_out.buffer - ctx_in.buffer, testing::Eq(params.expectedDataOffset));


### PR DESCRIPTION
This fixes a concern on invalid RLP decoding found during our internal audit. The original problem cannot be triggered currently on Ledger due to the fact that transactions are max 8kB and mis-parsing happens at 64kB but it is better to explicitly reject data we cannot parse