### PR TITLE
Create account changes

### DIFF
--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -537,6 +537,9 @@ parser_error_t parser_getItemCreateAccount(const parser_context_t *ctx,
     displayIdx--;
 
     const uint8_t pkCount = _countArgumentItems(&parser_tx_obj.arguments, 0);
+    if (pkCount > 5) {
+        return PARSER_UNEXPECTED_NUMBER_ITEMS;
+    }
     if (displayIdx < pkCount) {
         snprintf(outKey, outKeyLen, "Pub key %d", displayIdx + 1);
         CHECK_PARSER_ERR(

--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -72,7 +72,7 @@ parser_error_t parser_validate(const parser_context_t *ctx) {
 }
 
 parser_error_t parser_getNumItems(const parser_context_t *ctx, uint8_t *num_items) {
-    *num_items = _getNumItems(ctx, &parser_tx_obj);
+    CHECK_PARSER_ERR(_getNumItems(ctx, &parser_tx_obj, num_items))
     return PARSER_OK;
 }
 
@@ -515,6 +515,7 @@ parser_error_t parser_getItemTokenTransfer(const parser_context_t *ctx,
     return PARSER_DISPLAY_IDX_OUT_OF_RANGE;
 }
 
+#define CREATE_ACCOUNT_MAX_PUB_KEYS 5
 parser_error_t parser_getItemCreateAccount(const parser_context_t *ctx,
                                            uint16_t displayIdx,
                                            char *outKey, uint16_t outKeyLen,
@@ -536,10 +537,9 @@ parser_error_t parser_getItemCreateAccount(const parser_context_t *ctx,
     }
     displayIdx--;
 
-    const uint8_t pkCount = _countArgumentItems(&parser_tx_obj.arguments, 0);
-    if (pkCount > 5) {
-        return PARSER_UNEXPECTED_NUMBER_ITEMS;
-    }
+    uint8_t pkCount = 0;
+    CHECK_PARSER_ERR(_countArgumentItems(&parser_tx_obj.arguments, 0, 
+                                         CREATE_ACCOUNT_MAX_PUB_KEYS, &pkCount));
     if (displayIdx < pkCount) {
         snprintf(outKey, outKeyLen, "Pub key %d", displayIdx + 1);
         CHECK_PARSER_ERR(
@@ -1741,6 +1741,7 @@ parser_error_t parser_getItemRegisterDelegatorSCO(const parser_context_t *ctx,
 }
 
 //SCO.03
+#define SCO03_REGISTER_NODE_MAX_PUB_KEYS 3
 parser_error_t parser_getItemRegisterNodeSCO(const parser_context_t *ctx,
                                        uint16_t displayIdx,
                                        char *outKey, uint16_t outKeyLen,
@@ -1790,11 +1791,9 @@ parser_error_t parser_getItemRegisterNodeSCO(const parser_context_t *ctx,
     displayIdx -= 8;
     
 
-    const uint8_t pkCount = _countArgumentOptionalItems(&parser_tx_obj.arguments, 6);
-    //Maximal number of public keys is 3
-    if (pkCount > 3) { 
-        return PARSER_UNEXPECTED_VALUE;
-    }
+    uint8_t pkCount = 0;
+    CHECK_PARSER_ERR(_countArgumentOptionalItems(&parser_tx_obj.arguments, 6, 
+                                                SCO03_REGISTER_NODE_MAX_PUB_KEYS, &pkCount))
     if (displayIdx < pkCount) {
         snprintf(outKey, outKeyLen, "Pub key %d", displayIdx + 1);
         CHECK_PARSER_ERR(
@@ -1841,6 +1840,7 @@ parser_error_t parser_getItemRegisterNodeSCO(const parser_context_t *ctx,
 }
 
 //SCO.04
+#define SCO04_CREATE_MACHINE_ACOUNT_MAX_PUB_KEYS 3
 parser_error_t parser_getItemCreateMachineAccount(const parser_context_t *ctx,
                                        uint16_t displayIdx,
                                        char *outKey, uint16_t outKeyLen,
@@ -1868,10 +1868,9 @@ parser_error_t parser_getItemCreateMachineAccount(const parser_context_t *ctx,
     displayIdx -= 3;
     
 
-    const uint8_t pkCount = _countArgumentItems(&parser_tx_obj.arguments, 1);
-    if (pkCount > 3) { 
-        return PARSER_UNEXPECTED_VALUE;
-    }
+    uint8_t pkCount = 0;
+    CHECK_PARSER_ERR(_countArgumentItems(&parser_tx_obj.arguments, 1, 
+                                         SCO04_CREATE_MACHINE_ACOUNT_MAX_PUB_KEYS, &pkCount));
     if (displayIdx < pkCount) {
         snprintf(outKey, outKeyLen, "Pub key %d", displayIdx + 1);
         CHECK_PARSER_ERR(

--- a/app/src/parser_impl.c
+++ b/app/src/parser_impl.c
@@ -688,11 +688,13 @@ parser_error_t _validateTx(const parser_context_t *c, const parser_tx_t *v) {
     return PARSER_OK;
 }
 
-uint8_t _countArgumentItems(const flow_argument_list_t *v, uint8_t argumentIndex) {
+parser_error_t _countArgumentItems(const flow_argument_list_t *v, uint8_t argumentIndex, 
+                                   uint8_t max_number_of_items, uint8_t *number_of_items) {
+    *number_of_items = 0;
     parsed_json_t parsedJson = {false};
 
     if (argumentIndex >= v->argCount) {
-        return 0;
+        return PARSER_UNEXPECTED_FIELD;
     }
 
     const parser_context_t argCtx = v->argCtx[argumentIndex];
@@ -703,121 +705,164 @@ uint8_t _countArgumentItems(const flow_argument_list_t *v, uint8_t argumentIndex
     CHECK_PARSER_ERR(json_matchKeyValue(&parsedJson, 0, (char *) "Array", JSMN_ARRAY, &internalTokenElementIdx));
     uint16_t arrayTokenCount;
     CHECK_PARSER_ERR(array_get_element_count(&parsedJson, internalTokenElementIdx, &arrayTokenCount));
-    if (arrayTokenCount > 64) {
+    if (arrayTokenCount > max_number_of_items) {
         return PARSER_UNEXPECTED_NUMBER_ITEMS;
     }
 
-    return arrayTokenCount;
+    *number_of_items = arrayTokenCount;
+    return PARSER_OK;
 }
 
-
-uint8_t _countArgumentOptionalItems(const flow_argument_list_t *v, uint8_t argumentIndex) {
+//if Optional is null, number_of_items is set to 1 as one screen is needed to dispay "None"
+parser_error_t _countArgumentOptionalItems(const flow_argument_list_t *v, uint8_t argumentIndex, 
+                                           uint8_t max_number_of_items, uint8_t *number_of_items) {
+    *number_of_items = 0;
     parsed_json_t parsedJson = {false};
 
     if (argumentIndex >= v->argCount) {
-        return 0;
+        return PARSER_UNEXPECTED_FIELD;
     }
 
     const parser_context_t argCtx = v->argCtx[argumentIndex];
-    parser_error_t err = json_parse(&parsedJson, (char *) argCtx.buffer, argCtx.bufferLen);
-    if (err != PARSER_OK) {
-        return 0;
-    }
+    CHECK_PARSER_ERR(json_parse(&parsedJson, (char *) argCtx.buffer, argCtx.bufferLen));
 
-    // Get numnber of items
     uint16_t internalTokenElementIdx;
-    err = json_matchOptionalArray(&parsedJson, 0, &internalTokenElementIdx);
-    if (err != PARSER_OK) {
-        return 0;
-    }
+    CHECK_PARSER_ERR(json_matchOptionalArray(&parsedJson, 0, &internalTokenElementIdx));
     if (internalTokenElementIdx == JSON_MATCH_VALUE_IDX_NONE) {
-        return 1;
+        *number_of_items = 1;
+        return PARSER_OK;
     }
     
+    // Get numnber of items
     uint16_t arrayTokenCount;
-    err = array_get_element_count(&parsedJson, internalTokenElementIdx, &arrayTokenCount);
-    if (err != PARSER_OK || arrayTokenCount > 64) {
-        return 0;
+    CHECK_PARSER_ERR(array_get_element_count(&parsedJson, internalTokenElementIdx, &arrayTokenCount));
+    if (arrayTokenCount > max_number_of_items) {
+        return PARSER_UNEXPECTED_NUMBER_ITEMS;
     }
-    return arrayTokenCount;
+
+    *number_of_items = arrayTokenCount;
+    return PARSER_OK;
 }
 
-uint8_t _getNumItems(const parser_context_t *c, const parser_tx_t *v) {
+parser_error_t _getNumItems(const parser_context_t *c, const parser_tx_t *v, uint8_t *numItems) {
+    uint8_t argArrayLength = 0;
     switch (v->script.type) {
         case SCRIPT_TOKEN_TRANSFER:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_CREATE_ACCOUNT:
-            return 8 + _countArgumentItems(&v->arguments, 0) + v->authorizers.authorizer_count;
+            //array length is checked while we are parsing it        
+            CHECK_PARSER_ERR(_countArgumentItems(&v->arguments, 0, UINT8_MAX, &argArrayLength))
+            *numItems = 8 + argArrayLength + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_ADD_NEW_KEY:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH01_WITHDRAW_UNLOCKED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH02_DEPOSIT_UNLOCKED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH06_REGISTER_NODE:
-            return 14 + v->authorizers.authorizer_count;
+            *numItems = 14 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH08_STAKE_NEW_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH09_RESTAKE_UNSTAKED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH10_RESTAKE_REWARDED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH11_UNSTAKE_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH12_UNSTAKE_ALL_TOKENS:
-            return 8 + v->authorizers.authorizer_count;
+            *numItems = 8 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH13_WITHDRAW_UNSTAKED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH14_WITHDRAW_REWARDED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH16_REGISTER_OPERATOR_NODE:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH17_REGISTER_DELEGATOR:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH19_DELEGATE_NEW_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH20_RESTAKE_UNSTAKED_DELEGATED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH21_RESTAKE_REWARDED_DELEGATED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH22_UNSTAKE_DELEGATED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH23_WITHDRAW_UNSTAKED_DELEGATED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_TH24_WITHDRAW_REWARDED_DELEGATED_TOKENS:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO01_SETUP_STAKING_COLLECTION:
-            return 8 + v->authorizers.authorizer_count;
+            *numItems = 8 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO02_REGISTER_DELEGATOR:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO03_REGISTER_NODE:
-            return 14 + _countArgumentOptionalItems(&v->arguments, 6) + v->authorizers.authorizer_count;
+            //array length is checked while we are parsing it
+            CHECK_PARSER_ERR(_countArgumentOptionalItems(&v->arguments, 6, UINT8_MAX, &argArrayLength)); 
+            *numItems = 14 + argArrayLength + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO04_CREATE_MACHINE_ACCOUNT:
-            return 9 + _countArgumentItems(&v->arguments, 1) + v->authorizers.authorizer_count;
+            //array length is checked while we are parsing it
+            CHECK_PARSER_ERR(_countArgumentItems(&v->arguments, 1, UINT8_MAX, &argArrayLength)) 
+            *numItems = 9 + argArrayLength + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO05_REQUEST_UNSTAKING:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO06_STAKE_NEW_TOKENS:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO07_STAKE_REWARD_TOKENS:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO08_STAKE_UNSTAKED_TOKENS:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO09_UNSTAKE_ALL:
-            return 9 + v->authorizers.authorizer_count;
+            *numItems = 9 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO10_WITHDRAW_REWARD_TOKENS:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO11_WITHDRAW_UNSTAKED_TOKENS:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO12_CLOSE_STAKE:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO13_TRANSFER_NODE:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO14_TRANSFER_DELEGATOR:
-            return 11 + v->authorizers.authorizer_count;
+            *numItems = 11 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_SCO15_WITHDRAW_FROM_MACHINE_ACCOUNT:
-            return 10 + v->authorizers.authorizer_count;
+            *numItems = 10 + v->authorizers.authorizer_count;
+            return PARSER_OK;
         case SCRIPT_UNKNOWN:
         default:
-            return 0;
+            return PARSER_UNEXPECTED_SCRIPT;
     }
 }

--- a/app/src/parser_impl.h
+++ b/app/src/parser_impl.h
@@ -36,11 +36,16 @@ parser_error_t _read(parser_context_t *c, parser_tx_t *v);
 
 parser_error_t _validateTx(const parser_context_t *c, const parser_tx_t *v);
 
-uint8_t _getNumItems(const parser_context_t *c, const parser_tx_t *v);
+parser_error_t _getNumItems(const parser_context_t *c, const parser_tx_t *v, uint8_t *numItems);
 
-uint8_t _countArgumentItems(const flow_argument_list_t *v, uint8_t argumentIndex);
+//Called when argumentIndex-th argument is an array. If the array length is more than max_number_of_items
+//returns parser error, otherwise it sets number_of_items as the array length. 
+parser_error_t _countArgumentItems(const flow_argument_list_t *v, uint8_t argumentIndex, 
+                                   uint8_t max_number_of_items, uint8_t *number_of_items);
 
-uint8_t _countArgumentOptionalItems(const flow_argument_list_t *v, uint8_t argumentIndex);
+//Same as _countArgumentItems, but the array is optional.
+parser_error_t _countArgumentOptionalItems(const flow_argument_list_t *v, uint8_t argumentIndex, 
+                                           uint8_t max_number_of_items, uint8_t *number_of_items);
 
 parser_error_t json_validateToken(parsed_json_t *parsedJson, uint16_t tokenIdx);
 

--- a/tests/generate-transaction-tests/index.js
+++ b/tests/generate-transaction-tests/index.js
@@ -534,6 +534,44 @@ const invalidPayloadCases = [
     }),
     MAINNET,
   ],
+  [
+    "Example Transaction - Invalid Payload - Create Account - Too Many Public Keys",
+    buildPayloadTx(MAINNET, {
+      script: TX_CREATE_ACCOUNT,
+      arguments: [
+        {
+          "type": "Array",
+          "value": [
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            },
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            },
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            },
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            },
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            },
+            {
+              "type": "String",
+              "value": "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb29feaeb4559fdb71a97e2fd0438565310e87670035d83bc10fe67fe314dba5363c81654595d64884b1ecad1512a64e65e020164"
+            }
+          ]
+        }
+      ]
+    }),
+    MAINNET,
+  ],
 ].map(createPayloadTestcase(false));
 
 const validPayloadTransferCases = 
@@ -631,7 +669,7 @@ const validPayloadCases = [
       MAINNET,
     ]
   )),
-  ...(range(1, 5).map((i) => 
+  ...(range(1, 6).map((i) => 
     [
       `Create Account Transaction - Valid Payload - Multiple Account Keys #${i}`,
       buildPayloadTx(MAINNET, {
@@ -828,7 +866,7 @@ const validEnvelopeCases = [
       MAINNET,
     ]
   )),
-  ...(range(1, 5).map((i) => 
+  ...(range(1, 6).map((i) => 
     [
       `Create Account Transaction - Valid Envelope - Multiple Account Keys #${i}`,
       buildEnvelopeTx(MAINNET, {


### PR DESCRIPTION
Fixes an issue with _countArgumentItems function returning parser error values as number of elements in an array.
Bounds the number of Public Keys arguments in create account to 5. We discussed the max to be 3, but there were existing tests containing 4 arguments, so maybe 5 is a better bound. Tests added to verify code behavior when more than 5 public keys are present in the transaction.