### PR TITLE
Speculos transport change

### DIFF
--- a/deps/ledger-zxlib/dockerized_build.mk
+++ b/deps/ledger-zxlib/dockerized_build.mk
@@ -281,7 +281,7 @@ generate_test_vectors:
 # Note: This error did occur once: docker: Error response from daemon: driver failed programming external connectivity on endpoint speculos-port-5002 (082ea92d039f260880bc264a2f6086e14c42d698f24ff5acbba422baa9c60b29): Error starting userland proxy: listen tcp 0.0.0.0:41002: bind: address already in use.
 # Note: Since we do not need to use the VNC for the tests, then remove this option and hope the error never shows up again: --vnc-port $(3)
 define start_speculos_container
-	docker run --detach --name speculos-port-$(1) --rm -it -v $(CURDIR)/app:/speculos/app --publish $(1):$(1) --publish $(3):$(3) speculos --model nanos --sdk 2.0 --seed "equip will roof matter pink blind book anxiety banner elbow sun young" --display headless --apdu-port $(2) --api-port $(1) ./app/bin/app.elf ; rm -f ../speculos-port-$(1).log ; docker logs --follow speculos-port-$(1) 2>&1 | tee -a ../speculos-port-$(1).log > /dev/null 2>&1 &
+	docker run --detach --name speculos-port-$(1) --rm -it -v $(CURDIR)/app:/speculos/app --publish $(1):$(1) --publish $(2):$(2) --publish $(3):$(3) speculos --model nanos --sdk 2.0 --seed "equip will roof matter pink blind book anxiety banner elbow sun young" --display headless --apdu-port $(2) --api-port $(1) ./app/bin/app.elf ; rm -f ../speculos-port-$(1).log ; docker logs --follow speculos-port-$(1) 2>&1 | tee -a ../speculos-port-$(1).log > /dev/null 2>&1 &
 	@perl -e 'use Time::HiRes; $$t1=Time::HiRes::time(); while(1){ $$o=`cat ../speculos-port-$(1).log`; if($$o =~ m~Running on .*\:$(1)~s){ printf qq[# detected -- via log -- speculos listening after %f seconds; spy on emulated device via http://localhost:$(1)/\n], Time::HiRes::time() - $$t1; exit; } Time::HiRes::sleep(0.01); };'
 endef
 
@@ -295,27 +295,27 @@ define run_announce
 endef
 
 define run_nodejs_test
-	@cd $(TESTS_SPECULOS_DIR) && TEST_SPECULOS_API_PORT=$(1) node $(2) 2>&1 | tee -a ../../speculos-port-$(1).log 2>&1 | perl -lane '$$lines .= $$_ . "\n"; printf qq[%s\n], $$_ if(m~test(Start|Combo|Step|End)~); sub END{ die qq[ERROR: testEnd not detected; test failed?\n] if($$lines !~ m~testEnd~s); }'
+	@cd $(TESTS_SPECULOS_DIR) && TEST_SPECULOS_API_PORT=$(1) TEST_SPECULOS_APDU_PORT=$(2) node $(3) 2>&1 | tee -a ../../speculos-port-$(1).log 2>&1 | perl -lane '$$lines .= $$_ . "\n"; printf qq[%s\n], $$_ if(m~test(Start|Combo|Step|End)~); sub END{ die qq[ERROR: testEnd not detected; test failed?\n] if($$lines !~ m~testEnd~s); }'
 endef
 
 .PHONY: speculos_port_5001_test_internal
 speculos_port_5001_test_internal:
 	$(call run_announce,$@)
-	$(call run_nodejs_test,5001,test-basic-app-version.js)
-	$(call run_nodejs_test,5001,test-basic-slot-status-bad-net.js)
-	$(call run_nodejs_test,5001,test-basic-slot-status-full.js)
-	$(call run_nodejs_test,5001,test-basic-sign-basic-invalid.js)
-	$(call run_nodejs_test,5001,test-basic-get-address-secp256k1.js)
-	$(call run_nodejs_test,5001,test-basic-show-address-secp256k1.js)
-	$(call run_nodejs_test,5001,test-basic-get-address-secp256r1.js)
-	$(call run_nodejs_test,5001,test-basic-show-address-secp256r1.js)
-	$(call run_nodejs_test,5001,test-basic-show-address-expert.js)
+	$(call run_nodejs_test,5001,40001,test-basic-app-version.js)
+	$(call run_nodejs_test,5001,40001,test-basic-slot-status-bad-net.js)
+	$(call run_nodejs_test,5001,40001,test-basic-slot-status-full.js)
+	$(call run_nodejs_test,5001,40001,test-basic-sign-basic-invalid.js)
+	$(call run_nodejs_test,5001,40001,test-basic-get-address-secp256k1.js)
+	$(call run_nodejs_test,5001,40001,test-basic-show-address-secp256k1.js)
+	$(call run_nodejs_test,5001,40001,test-basic-get-address-secp256r1.js)
+	$(call run_nodejs_test,5001,40001,test-basic-show-address-secp256r1.js)
+	$(call run_nodejs_test,5001,40001,test-basic-show-address-expert.js)
 	@echo "# ALL TESTS COMPLETED!" | tee -a ../speculos-port-5001.log
 
 .PHONY: speculos_port_5002_test_internal
 speculos_port_5002_test_internal:
 	$(call run_announce,$@)
-	$(call run_nodejs_test,5002,test-transactions.js)
+	$(call run_nodejs_test,5002,40002,test-transactions.js)
 	@echo "# ALL TESTS COMPLETED!" | tee -a ../speculos-port-5002.log
 
 .PHONY: speculos_port_5001_test

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -232,14 +232,6 @@ export default class FlowApp {
       const errorCodeData = response.slice(-2);
       const returnCode = errorCodeData[0] * 256 + errorCodeData[1];
 
-      if (returnCode != 0x9000) {
-        return {
-          returnCode,
-          errorMessage: errorCodeToString(returnCode),
-          slotIdx: slotIdx,
-        };  
-      }
-
       const pathStr = printBIP44Path(response.slice(8, 28));
 
       return {

--- a/tests_speculos/package.json
+++ b/tests_speculos/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
+    "@ledgerhq/hw-transport-node-speculos": "^6.20.0",
     "@onflow/ledger": "file:../js"
   },
   "devDependencies": {

--- a/tests_speculos/test-basic-app-version.js
+++ b/tests_speculos/test-basic-app-version.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 common.curlScreenShot(scriptName); console.log(common.humanTime() + " // screen shot before sending first apdu command");
 
 //getVersion
@@ -24,14 +25,15 @@ assert.equal(getVersionResponse.major, 0);
 assert.equal(getVersionResponse.minor, 9);
 assert.equal(getVersionResponse.patch, 12)
 assert.ok("testMode" in getVersionResponse)
-assert.equal(common.mockTransport.hexApduCommandOut.length, 1)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 1)
+assert.equal(transport.hexApduCommandOut.length, 1)
+assert.equal(transport.hexApduCommandIn.length, 1)
 
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3300000000";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "0000090c00311000049000";
 common.compare(hexIncomming, hexExpected, "apdu response", {testMode:1, major:1, minor:1, patch:1, deviceLocked:1, targetId:4, returnCode:2, unexpected:9999});
 
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-get-address-secp256k1.js
+++ b/tests_speculos/test-basic-get-address-secp256k1.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 const scheme = FlowApp.Signature.SECP256K1 | FlowApp.Hash.SHA2_256;
 const path = `m/44'/539'/${scheme}'/0/0`;
 
@@ -28,12 +29,12 @@ const expected_pk = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc
 assert.equal(getPubkeyResponse.address.toString(), expected_pk);
 assert.equal(getPubkeyResponse.publicKey.toString('hex'), expected_pk);
 
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3301000014xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, do_not_compare_path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc4b9fad34a415828d924ec7b83ac0eddf22ef115b7c203ee39fb080572d7e51775ee54be303464373438326262616666373832373033356435623233386466333138623130363034363733646336313338303837323365666264323366626334623966616433346134313538323864393234656337623833616330656464663232656631313562376332303365653339666230383035373264376535313737356565353462659000";
 common.compare(hexIncomming, hexExpected, "apdu response", {publicKey:65, publicKey_hex:130, returnCode:2, unexpected:9999});
 
-
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-get-address-secp256r1.js
+++ b/tests_speculos/test-basic-get-address-secp256r1.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 const scheme = FlowApp.Signature.P256 | FlowApp.Hash.SHA2_256;
 const path = `m/44'/539'/${scheme}'/0/0`;
 
@@ -28,13 +29,14 @@ const expected_pk = "04db0a14364e5bf43a7ddda603522ddfee95c5ff12b48c49480f062e7aa
 assert.equal(getPubkeyResponse.address, expected_pk);
 assert.equal(getPubkeyResponse.publicKey.toString('hex'), expected_pk);
 
-assert.equal(common.mockTransport.hexApduCommandOut.length, 1)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 1)
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+assert.equal(transport.hexApduCommandOut.length, 1)
+assert.equal(transport.hexApduCommandIn.length, 1)
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3301000014xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, do_not_compare_path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "04db0a14364e5bf43a7ddda603522ddfee95c5ff12b48c49480f062e7aa9d20e84215eef9b8b76175f32802f75ed54110e29c7dc76054f24c028c312098e7177a3303464623061313433363465356266343361376464646136303335323264646665653935633566663132623438633439343830663036326537616139643230653834323135656566396238623736313735663332383032663735656435343131306532396337646337363035346632346330323863333132303938653731373761339000";
 common.compare(hexIncomming, hexExpected, "apdu response", {publicKey:65, publicKey_hex:130, returnCode:2, unexpected:9999});
 
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-show-address-expert.js
+++ b/tests_speculos/test-basic-show-address-expert.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 console.log(common.humanTime() + " // Derivation path. First 3 items are automatically hardened!");
 const scheme = FlowApp.Signature.SECP256K1 | FlowApp.Hash.SHA2_256;
 const path = `m/44'/539'/${scheme}'/0/0`;
@@ -43,12 +44,12 @@ const expected_pk = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc
 assert.equal(showPubkeyResponse.address.toString(), expected_pk);
 assert.equal(showPubkeyResponse.publicKey.toString('hex'), expected_pk);
 
-assert.equal(common.mockTransport.hexApduCommandOut.length, 1)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 1)
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+assert.equal(transport.hexApduCommandOut.length, 1)
+assert.equal(transport.hexApduCommandIn.length, 1)
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3301010014xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, do_not_compare_path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc4b9fad34a415828d924ec7b83ac0eddf22ef115b7c203ee39fb080572d7e51775ee54be303464373438326262616666373832373033356435623233386466333138623130363034363733646336313338303837323365666264323366626334623966616433346134313538323864393234656337623833616330656464663232656631313562376332303365653339666230383035373264376535313737356565353462659000";
 common.compare(hexIncomming, hexExpected, "apdu response", {publicKey:65, publicKey_hex:130, returnCode:2, unexpected:9999});
 
@@ -57,4 +58,6 @@ common.testStep("   +  ", "buttons; enable expert mode");
 common.curlButton('right', "; Expert mode: enabled"); common.curlScreenShot(scriptName);
 common.curlButton('both' , "; Expert mode: disabled" ); common.curlScreenShot(scriptName);
 common.curlButton('left' , "; Flow Ready"           ); common.curlScreenShot(scriptName);
+
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-show-address-secp256k1.js
+++ b/tests_speculos/test-basic-show-address-secp256k1.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 console.log(common.humanTime() + " // Derivation path. First 3 items are automatically hardened!");
 const scheme = FlowApp.Signature.SECP256K1 | FlowApp.Hash.SHA2_256;
 const path = `m/44'/539'/${scheme}'/0/0`;
@@ -36,13 +37,14 @@ const expected_pk = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc
 assert.equal(showPubkeyResponse.address.toString(), expected_pk);
 assert.equal(showPubkeyResponse.publicKey.toString('hex'), expected_pk);
 
-assert.equal(common.mockTransport.hexApduCommandOut.length, 1)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 1)
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+assert.equal(transport.hexApduCommandOut.length, 1)
+assert.equal(transport.hexApduCommandIn.length, 1)
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3301010014xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, do_not_compare_path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "04d7482bbaff7827035d5b238df318b10604673dc613808723efbd23fbc4b9fad34a415828d924ec7b83ac0eddf22ef115b7c203ee39fb080572d7e51775ee54be303464373438326262616666373832373033356435623233386466333138623130363034363733646336313338303837323365666264323366626334623966616433346134313538323864393234656337623833616330656464663232656631313562376332303365653339666230383035373264376535313737356565353462659000";
 common.compare(hexIncomming, hexExpected, "apdu response", {publicKey:65, publicKey_hex:130, returnCode:2, unexpected:9999});
 
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-show-address-secp256r1.js
+++ b/tests_speculos/test-basic-show-address-secp256r1.js
@@ -10,9 +10,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 console.log(common.humanTime() + " // Derivation path. First 3 items are automatically hardened!");
 const scheme = FlowApp.Signature.P256 | FlowApp.Hash.SHA2_256;
 const path = `m/44'/539'/${scheme}'/0/0`; 
@@ -35,13 +36,14 @@ const expected_pk = "04db0a14364e5bf43a7ddda603522ddfee95c5ff12b48c49480f062e7aa
 assert.equal(showPubkeyResponse.address, expected_pk);
 assert.equal(showPubkeyResponse.publicKey.toString('hex'), expected_pk);
 
-assert.equal(common.mockTransport.hexApduCommandOut.length, 1)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 1)
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+assert.equal(transport.hexApduCommandOut.length, 1)
+assert.equal(transport.hexApduCommandIn.length, 1)
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "3301010014xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, do_not_compare_path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "04db0a14364e5bf43a7ddda603522ddfee95c5ff12b48c49480f062e7aa9d20e84215eef9b8b76175f32802f75ed54110e29c7dc76054f24c028c312098e7177a3303464623061313433363465356266343361376464646136303335323264646665653935633566663132623438633439343830663036326537616139643230653834323135656566396238623736313735663332383032663735656435343131306532396337646337363035346632346330323863333132303938653731373761339000";
 common.compare(hexIncomming, hexExpected, "apdu response", {publicKey:65, publicKey_hex:130, returnCode:2, unexpected:9999});
 
+await transport.close()
 common.testEnd(scriptName);

--- a/tests_speculos/test-basic-sign-basic-invalid.js
+++ b/tests_speculos/test-basic-sign-basic-invalid.js
@@ -12,9 +12,10 @@ var scriptName = common.path.basename(fileURLToPath(import.meta.url));
 common.testStart(scriptName);
 
 const FlowApp = OnflowLedgerMod.default;
-const app = new FlowApp(common.mockTransport);
+const transport = await common.getSpyTransport()
+const app = new FlowApp(transport);
 
-console.log(common.humanTime() + " // using FlowApp below with common.mockTransport() to grab apdu command without sending it");
+console.log(common.humanTime() + " // using FlowApp below with transport() to grab apdu command without sending it");
 const slot = 1;
 const address = "e467b9dd11fa00df"
 const scheme = FlowApp.Signature.SECP256K1 | FlowApp.Hash.SHA2_256;
@@ -32,21 +33,20 @@ invalidMessage += "1";
 common.testStep(" - - -", "await app.sign() // path=" + path + " invalidMessage=..");
 const signResponse = await app.sign(path, invalidMessage);
 assert.equal(signResponse.returnCode, 0x6984);
-assert.equal(signResponse.errorMessage, "Data is invalid : parser_rlp_error_invalid_kind");
+assert.equal(signResponse.errorMessage, "Data is invalid");
 
-assert.equal(common.mockTransport.hexApduCommandOut.length, 2)
-assert.equal(common.mockTransport.hexApduCommandIn.length, 2)
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+assert.equal(transport.hexApduCommandOut.length, 2)
+assert.equal(transport.hexApduCommandIn.length, 1)
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "33020000142c0000801b020080010200800000000000000000";
 common.compare(hexOutgoing, hexExpected, "apdu command", {cla:1, ins:1, p1:1, p2:1, len:1, path:20, unexpected:9999});
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
+var hexIncomming = transport.hexApduCommandIn.shift();
 var hexExpected = "9000";
 common.compare(hexIncomming, hexExpected, "apdu response", {returnCode:2, unexpected:9999});
 
-var hexOutgoing = common.mockTransport.hexApduCommandOut.shift();
+var hexOutgoing = transport.hexApduCommandOut.shift();
 var hexExpected = "330202000812345678efbfbd31";
-var hexIncomming = common.mockTransport.hexApduCommandIn.shift();
-var hexExpected = "7061727365725f726c705f6572726f725f696e76616c69645f6b696e646984";
-common.compare(hexIncomming, hexExpected, "apdu response", {signatureCompact:29, returnCode:2, unexpected:9999});
+common.compare(hexOutgoing, hexExpected, "apdu response", {cla:1, ins:1, p1:1, p2:1, len:1, message:8, unexpected:9999});
 
+await transport.close()
 common.testEnd(scriptName);


### PR DESCRIPTION
- Transport for speculos tests (for APDUs) changed to @ledgerhq/hw-transport-node-speculos
- Undo js change that was required due to mocked transport in speculos tests handling errors differently than ledgerhq transports.
- Update SDK
