### PR TITLE
Refactor argument displaying code

### DIFF
--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -192,7 +192,7 @@ parser_error_t parser_printArgument(const flow_argument_list_t *v, uint8_t argIn
 parser_error_t parser_printOptionalArgument(const flow_argument_list_t *v, uint8_t argIndex,
                                                char *expectedType, jsmntype_t jsonType,
                                                char *outVal, uint16_t outValLen,
-                                               __Z_UNUSED uint8_t pageIdx, uint8_t *pageCount) {
+                                               uint8_t pageIdx, uint8_t *pageCount) {
     MEMZERO(outVal, outValLen);
 
     if (argIndex >= v->argCount) {

--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -212,7 +212,9 @@ parser_error_t parser_printOptionalArgument(const flow_argument_list_t *v, uint8
         strncpy_s(outVal, "None", 5);
     }
     else {
-        CHECK_PARSER_ERR(json_extractToken(outVal, outValLen, &parsedJson, valueTokenIndex))
+        char bufferUI[ARGUMENT_BUFFER_SIZE_STRING];
+        CHECK_PARSER_ERR(json_extractToken(bufferUI, sizeof(bufferUI), &parsedJson, valueTokenIndex))
+        pageString(outVal, outValLen, bufferUI, pageIdx, pageCount);
     }
 
     return PARSER_OK;

--- a/app/src/parser.h
+++ b/app/src/parser.h
@@ -49,9 +49,9 @@ parser_error_t parser_getItem(const parser_context_t *ctx,
 
 ////for testing purposes
 parser_error_t parser_printOptionalArgument(const flow_argument_list_t *v, uint8_t argIndex,
-                                               char *expectedType, jsmntype_t jsonType,
-                                               char *outVal, uint16_t outValLen,
-                                               uint8_t pageIdx, uint8_t *pageCount);
+                                            char *expectedType, jsmntype_t jsonType,
+                                            char *outVal, uint16_t outValLen,
+                                            uint8_t pageIdx, uint8_t *pageCount);
 
 parser_error_t parser_printArgumentOptionalArray(const flow_argument_list_t *v, uint8_t argIndex, uint8_t arrayIndex,
                                                  char *expectedType, jsmntype_t jsonType,

--- a/app/src/parser.h
+++ b/app/src/parser.h
@@ -45,16 +45,18 @@ parser_error_t parser_getItem(const parser_context_t *ctx,
                               uint8_t pageIdx, uint8_t *pageCount);
 
 
+#ifdef __cplusplus
+
 ////for testing purposes
-parser_error_t parser_printArgumentOptionalDelegatorID(const flow_argument_list_t *v,
-                                               uint8_t argIndex, char *expectedType, jsmntype_t jsonType,
+parser_error_t parser_printOptionalArgument(const flow_argument_list_t *v, uint8_t argIndex,
+                                               char *expectedType, jsmntype_t jsonType,
                                                char *outVal, uint16_t outValLen,
                                                uint8_t pageIdx, uint8_t *pageCount);
 
-parser_error_t parser_printArgumentOptionalPublicKeys(const parser_context_t *argumentCtx, uint8_t argumentIndex,
-                                              char *outVal, uint16_t outValLen,
-                                              uint8_t pageIdx, uint8_t *pageCount);
+parser_error_t parser_printArgumentOptionalArray(const flow_argument_list_t *v, uint8_t argIndex, uint8_t arrayIndex,
+                                                 char *expectedType, jsmntype_t jsonType,
+                                                 char *outVal, uint16_t outValLen,
+                                                 uint8_t pageIdx, uint8_t *pageCount);
 
-#ifdef __cplusplus
 }
 #endif

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -40,18 +40,18 @@ flow_argument_list_t arg_list = {{},{context2, context3, context4, context5}, 4}
 
 
 
-TEST(parser, printOptionalDelegatorID) {
+TEST(parser, printOptionalArgument) {
     char outValBuf[40];
     uint8_t pageCountVar = 0;
 
     char ufix64[] = "UFix64";
-    parser_error_t err = parser_printArgumentOptionalDelegatorID(&arg_list, 0, ufix64, JSMN_STRING,
+    parser_error_t err = parser_printOptionalArgument(&arg_list, 0, ufix64, JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_THAT(pageCountVar, 1);
     EXPECT_STREQ(outValBuf, "None");
 
-    err = parser_printArgumentOptionalDelegatorID(&arg_list, 1, ufix64, JSMN_STRING,
+    err = parser_printOptionalArgument(&arg_list, 1, ufix64, JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "545.77");
@@ -59,82 +59,82 @@ TEST(parser, printOptionalDelegatorID) {
 }
 
 
-TEST(parser, printOptionalPublicKeys) {
+TEST(parser, printOptionalArray) {
     char outValBuf[40];
     uint8_t pageCountVar = 0;
 
-    parser_error_t err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[0], 0,
+    parser_error_t err = parser_printArgumentOptionalArray(&arg_list, 0, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_THAT(pageCountVar, 1);
     EXPECT_STREQ(outValBuf, "None");
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[2], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 2, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "f845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[2], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 2, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 1, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "29feaeb4559fdb71a97e2fd0438565310e87670");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[2], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 2, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 2, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "035d83bc10fe67fe314dba5363c81654595d648");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[2], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 2, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 3, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "84b1ecad1512a64e65e020164");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "e845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 1, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "29feaeb4559fdb71a97e2fd0438565310e87670");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 2, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "035d83bc10fe67fe314dba5363c81654595d648");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 0,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 0, "String", JSMN_STRING,
                                                outValBuf, 40, 3, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "84b1ecad1512a64e65e020164");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 1,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 1, "String", JSMN_STRING,
                                                outValBuf, 40, 0, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "d845b8406e4f43f79d3c1d8cacb3d5f3e7aeedb");
     EXPECT_THAT(pageCountVar, 4);
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 1,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 1, "String", JSMN_STRING,
                                                outValBuf, 40, 1, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "29feaeb4559fdb71a97e2fd0438565310e87670");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 1,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 1, "String", JSMN_STRING,
                                                outValBuf, 40, 2, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "035d83bc10fe67fe314dba5363c81654595d648");
     EXPECT_THAT(pageCountVar, 4);
 
-    err = parser_printArgumentOptionalPublicKeys(&arg_list.argCtx[3], 1,
+    err = parser_printArgumentOptionalArray(&arg_list, 3, 1, "String", JSMN_STRING,
                                                outValBuf, 40, 3, &pageCountVar);
     EXPECT_THAT(err, PARSER_OK);
     EXPECT_STREQ(outValBuf, "84b1ecad1512a64e65e020164");


### PR DESCRIPTION
Arguments now can be displayed using four methods:
- parser_printArgument
- parser_printOptionalArgument
- parser_printArgumentArray
- parser_printArgumentOptionalArray
Remove redundancy. Unify interface of these calls.